### PR TITLE
AS7-6390 I think this is the most generic way of dealing with this probl...

### DIFF
--- a/src/org/apache/xml/serializer/ToStream.java
+++ b/src/org/apache/xml/serializer/ToStream.java
@@ -3020,6 +3020,14 @@ abstract public class ToStream extends SerializerBase
             index = m_attributes.getIndex(rawName);
         else {
             index = m_attributes.getIndex(uri, localName);
+            /*
+             * SAX parser sometimes returns attributes with no 
+             * uri and localName defined. In such situation 
+             * attribute may be already defined but it is 
+             * not accessible querying by uri and localName
+             */
+            if(index < 0)
+            	index = m_attributes.getIndex(rawName);
         }
 
         if (index >= 0)


### PR DESCRIPTION
IMHO There is a problem with "http://xml.org/sax/features/namespace-prefixes" feature of SAX parser. When it is set to true attribute list of first element contains namespace definitions, moreover these attributes have parameters set incorrectly (at least AFAIK). So ... 
there are parameters like:
{qname="xmlns:wsdl", uri="", local=""}
while it suppose to be: 
{qname="xmlns:wsdl", uri="http://www.w3.org/2000/xmlns/", local="wsdl"}

Returning this namespace definitions as attributes causing they are processed once as "raw" attributes and then as namespace definitions. XALAN is checking for duplicated attributes based only on URI and local - so these two are different for IT.

I added lookup on qname if such URI/LOCAL lookup failed. 
